### PR TITLE
change local filters support boolean false value for checkbox filter

### DIFF
--- a/src/PrimevueDatatables.php
+++ b/src/PrimevueDatatables.php
@@ -89,7 +89,7 @@ class PrimevueDatatables
                             }
                         }
                     } else {
-                        if (collect($filter)->get("value")) {
+                        if (collect($filter)->get("value") !== null) {
                             $instance = new Filter($field, collect($filter)->get("value"), collect($filter)->get("matchMode"));
                             $this->applyFilter($instance, $q);
                         }


### PR DESCRIPTION
Local filter does not seem support for value boolean especially for false / 0 value. for example when user has checkbox filter with true / false value. This issue is solved by using !== comparison for the value. 